### PR TITLE
Use mock dependency in test env only

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule ExOpenAI.MixProject do
     [
       {:jason, "~> 1.4"},
       {:httpoison, "~> 1.8"},
-      {:mock, "~> 0.3.6"},
+      {:mock, "~> 0.3.6", only: :test},
       {:mix_test_watch, "~> 1.0"},
       {:ex_doc, ">= 0.19.2", only: :dev},
       {:exvcr, "~> 0.11", only: :test},


### PR DESCRIPTION
I've modified the mock dependency so it's only used in the test environment since it's a test-only dependency.