### PR TITLE
Add `http_headers` config option to allow beta headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ config :ex_openai,
   organization_key: System.get_env("OPENAI_ORGANIZATION_KEY"),
   # optional, passed to [HTTPoison.Request](https://hexdocs.pm/httpoison/HTTPoison.Request.html) options
   http_options: [recv_timeout: 50_000]
+  # optional, default request headers. The following header is required for Assistant endpoints, which are in beta as of December 2023.
+  http_headers: [
+    {"OpenAI-Beta", "assistants=v1"}
+  ]
 ```
 
 You can also pass `api_key` and `organization_key` directly by passing them into the `opts` argument when calling the openai apis:

--- a/lib/ex_openai/client.ex
+++ b/lib/ex_openai/client.ex
@@ -57,6 +57,8 @@ defmodule ExOpenAI.Client do
 
   def request_options(), do: Config.http_options()
 
+  def default_headers(), do: Config.http_headers()
+
   def stream_options(request_options, convert_response) do
     with {:ok, stream_val} <- Keyword.fetch(request_options, :stream),
          {:ok, stream_to} when is_pid(stream_to) or is_function(stream_to) <-
@@ -82,7 +84,7 @@ defmodule ExOpenAI.Client do
     request_options_map = Enum.into(request_options, %{})
 
     headers =
-      []
+      default_headers()
       |> add_json_request_headers()
       |> add_organization_header(Map.get(request_options_map, :openai_organization_key, nil))
       |> add_bearer_header(Map.get(request_options_map, :openai_api_key, nil))
@@ -114,7 +116,7 @@ defmodule ExOpenAI.Client do
     request_options_map = Enum.into(request_options, %{})
 
     headers =
-      []
+      default_headers()
       |> add_json_request_headers()
       |> add_organization_header(Map.get(request_options_map, :openai_organization_key, nil))
       |> add_bearer_header(Map.get(request_options_map, :openai_api_key, nil))
@@ -136,7 +138,7 @@ defmodule ExOpenAI.Client do
     request_options_map = Enum.into(request_options, %{})
 
     headers =
-      []
+      default_headers()
       |> add_json_request_headers()
       |> add_organization_header(Map.get(request_options_map, :openai_organization_key, nil))
       |> add_bearer_header(Map.get(request_options_map, :openai_api_key, nil))
@@ -181,7 +183,7 @@ defmodule ExOpenAI.Client do
        |> Enum.map(&multipart_param/1)}
 
     headers =
-      []
+      default_headers()
       |> add_multipart_request_headers()
       |> add_organization_header(Map.get(request_options_map, :openai_organization_key, nil))
       |> add_bearer_header(Map.get(request_options_map, :openai_api_key, nil))

--- a/lib/ex_openai/config.ex
+++ b/lib/ex_openai/config.ex
@@ -11,7 +11,8 @@ defmodule ExOpenAI.Config do
   @config_keys [
     :api_key,
     :organization_key,
-    :http_options
+    :http_options,
+    :http_headers
   ]
 
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -35,6 +36,8 @@ defmodule ExOpenAI.Config do
 
   # HTTP Options
   def http_options, do: get_config_value(:http_options, [])
+
+  def http_headers, do: get_config_value(:http_headers, [])
 
   defp get_config_value(key, default \\ nil) do
     value =


### PR DESCRIPTION
The Assistants API requires a special beta header, which is not currently supported.

This PR allows you to specify default headers, e.g.:

```
config :ex_openai,
  # ...
  http_headers: [
    {"OpenAI-Beta", "assistants=v1"}
  ]
```