### PR TITLE
Fix methods on the same URL getting ignored

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         otp: ['23.3']
-        elixir: ['1.11.4', '1.14.3']
+        elixir: ['1.14.3']
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.11.4-otp-23
+elixir 1.13.4-otp-23
 erlang 23.3.4.19

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExOpenAI.MixProject do
     [
       app: :ex_openai,
       version: "1.4.0",
-      elixir: "~> 1.11",
+      elixir: "~> 1.13",
       description: description(),
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
When multiple methods were usable on the same URL, only the first in order would get parsed and the rest ignored. 

Missing methods now show up correctly: 

```
iex(8)> ExOpenAI.Assistants.
create_assistant/1         create_assistant/2
create_assistant_file/2    create_assistant_file/3
delete_assistant/1         delete_assistant/2
delete_assistant_file/2    delete_assistant_file/3
get_assistant/1            get_assistant/2
get_assistant_file/2       get_assistant_file/3
list_assistant_files/1     list_assistant_files/2
list_assistants/0          list_assistants/1
modify_assistant/1         modify_assistant/2
```

Fixes #15