### PR TITLE
Add base_url override support, to allow changing the OpenAI endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ config :ex_openai,
   api_key: System.get_env("OPENAI_API_KEY"),
   # find it at https://platform.openai.com/account/api-keys
   organization_key: System.get_env("OPENAI_ORGANIZATION_KEY"),
+	# optional, other clients allow overriding via the OPENAI_API_URL/OPENAI_API_BASE environment variable,
+	# if unset the the default is https://api.openai.com/v1
+  base_url: System.get_env("OPENAI_API_URL"),
   # optional, passed to [HTTPoison.Request](https://hexdocs.pm/httpoison/HTTPoison.Request.html) options
   http_options: [recv_timeout: 50_000],
   # optional, default request headers. The following header is required for Assistant endpoints, which are in beta as of December 2023.

--- a/lib/ex_openai/config.ex
+++ b/lib/ex_openai/config.ex
@@ -32,7 +32,9 @@ defmodule ExOpenAI.Config do
   def org_key, do: get_config_value(:organization_key)
 
   # API Url
-  def api_url, do: @openai_url
+	# Other clients allow overriding via the OPENAI_API_URL/OPENAI_API_BASE environment variable,
+	# but this is set via config with the default being https://api.openai.com/v1
+  def api_url, do: get_config_value(:base_url, @openai_url)
 
   # HTTP Options
   def http_options, do: get_config_value(:http_options, [])

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -16,6 +16,13 @@ defmodule ExOpenAI.ConfigTest do
     assert Config.http_options() == [recv_timeout: 30_000]
   end
 
+	test "base_url/1 should return value or default" do
+		assert Config.api_url() == "https://api.openai.com/v1"
+
+		Application.put_env(@application, :base_url, "https://example.com/foobar")
+		assert Config.api_url() == "https://example.com/foobar"
+	end
+
   defp reset_env() do
     Application.get_all_env(@application)
     |> Keyword.keys()


### PR DESCRIPTION
The [OpenAI Python library](https://github.com/openai/openai-python/blob/main/src/openai/_client.py#L107) allows overriding the `base_url` when defining the client.

It would be great if we could do this on a config level, where `api_url` in `ExOpenAI.Config` could be defined in config like this:

```elixir
config :ex_openai,
  base_url: System.get_env("OPENAI_BASE_URL"),
```

Then it would override the base_url.

Let me know what you think of this, happy for any changes, it's a pretty basic change, so do what you think is best :).