### PR TITLE
Be able to override :base_url

### DIFF
--- a/lib/ex_openai/client.ex
+++ b/lib/ex_openai/client.ex
@@ -3,7 +3,7 @@ defmodule ExOpenAI.Client do
   use HTTPoison.Base
   alias ExOpenAI.Config
 
-  def process_url(url), do: Config.api_url() <> url
+  def add_base_url(url, base_url), do: Config.api_url(base_url) <> url
 
   def process_response_body(body) do
     case Jason.decode(body) do
@@ -98,7 +98,10 @@ defmodule ExOpenAI.Client do
       |> add_organization_header(Map.get(request_options_map, :openai_organization_key, nil))
       |> add_bearer_header(Map.get(request_options_map, :openai_api_key, nil))
 
+    base_url = Map.get(request_options_map, :base_url)
+
     url
+    |> add_base_url(base_url)
     |> get(headers, request_options)
     |> handle_response()
     |> convert_response.()
@@ -133,7 +136,10 @@ defmodule ExOpenAI.Client do
       |> add_organization_header(Map.get(request_options_map, :openai_organization_key, nil))
       |> add_bearer_header(Map.get(request_options_map, :openai_api_key, nil))
 
+    base_url = Map.get(request_options_map, :base_url)
+
     url
+    |> add_base_url(base_url)
     |> post(body, headers, request_options)
     |> handle_response()
     |> convert_response.()
@@ -155,7 +161,10 @@ defmodule ExOpenAI.Client do
       |> add_organization_header(Map.get(request_options_map, :openai_organization_key, nil))
       |> add_bearer_header(Map.get(request_options_map, :openai_api_key, nil))
 
+    base_url = Map.get(request_options_map, :base_url)
+
     url
+    |> add_base_url(base_url)
     |> delete(headers, request_options)
     |> handle_response()
     |> convert_response.()
@@ -203,7 +212,10 @@ defmodule ExOpenAI.Client do
       |> add_organization_header(Map.get(request_options_map, :openai_organization_key, nil))
       |> add_bearer_header(Map.get(request_options_map, :openai_api_key, nil))
 
+    base_url = Map.get(request_options_map, :base_url)
+
     url
+    |> add_base_url(base_url)
     |> post(multipart_body, headers, request_options)
     |> handle_response()
     |> convert_response.()

--- a/lib/ex_openai/config.ex
+++ b/lib/ex_openai/config.ex
@@ -13,7 +13,8 @@ defmodule ExOpenAI.Config do
     :organization_key,
     :http_options,
     :http_headers,
-    :http_client
+    :http_client,
+    :base_url
   ]
 
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -35,7 +36,9 @@ defmodule ExOpenAI.Config do
   # API Url
   # Other clients allow overriding via the OPENAI_API_URL/OPENAI_API_BASE environment variable,
   # but this is set via config with the default being https://api.openai.com/v1
-  def api_url, do: get_config_value(:base_url, @openai_url)
+  def api_url(override \\ nil) do
+    override || get_config_value(:base_url, @openai_url)
+  end
 
   # HTTP Options
   def http_options, do: get_config_value(:http_options, [])

--- a/lib/ex_openai/config.ex
+++ b/lib/ex_openai/config.ex
@@ -33,9 +33,6 @@ defmodule ExOpenAI.Config do
   def api_key, do: get_config_value(:api_key)
   def org_key, do: get_config_value(:organization_key)
 
-  # API Url
-  # Other clients allow overriding via the OPENAI_API_URL/OPENAI_API_BASE environment variable,
-  # but this is set via config with the default being https://api.openai.com/v1
   def api_url(override \\ nil) do
     override || get_config_value(:base_url, @openai_url)
   end

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -1,0 +1,30 @@
+defmodule ExOpenAI.ClientTest do
+  use ExUnit.Case
+  alias ExOpenAI.Client
+  alias ExOpenAI.Config
+
+  describe "api_url/1" do
+    test "returns default URL when no override is provided" do
+      assert Config.api_url() == "https://api.openai.com/v1"
+    end
+
+    test "returns overridden URL when provided" do
+      override_url = "https://custom-api.example.com/v1"
+      assert Config.api_url(override_url) == override_url
+    end
+  end
+
+  describe "add_base_url/2" do
+    test "adds base URL" do
+      url = "/chat/completions"
+      base_url = "https://api.openai.com/v1"
+      assert Client.add_base_url(url, base_url) == "https://api.openai.com/v1/chat/completions"
+    end
+
+    test "uses custom base URL when provided" do
+      url = "/chat/completions"
+      base_url = "https://custom-api.example.com/v1"
+      assert Client.add_base_url(url, base_url) == "https://custom-api.example.com/v1/chat/completions"
+    end
+  end
+end


### PR DESCRIPTION
These days one codebase usually uses more than one OpenAI compatible API provider at the same time.

This PR provides the ability to override the base URL. 

Example usage:

```elixir
msgs = [%{role: :user, content: "Hello!"}]

ExOpenAI.Chat.create_chat_completion(msgs, "hf:mistralai/Mistral-7B-Instruct-v0.3",
  base_url: "https://cheapai.local",
  openai_api_key: "1234"
)
  ```