### PR TITLE
Fix Elixir 1.18 compiler warning

### DIFF
--- a/lib/ex_openai/codegen.ex
+++ b/lib/ex_openai/codegen.ex
@@ -96,18 +96,10 @@ defmodule ExOpenAI.Codegen do
     ]
   end
 
-  @doc """
-  Extracts the group name from a given URL.
-
-  ## Examples
-
-      iex> UrlExtractor.extract_group_from_url("/fine-tunes/{fine_tune_id}")
-      "FineTunes"
-
-      iex> UrlExtractor.extract_group_from_url("/files/{file_id}/content")
-      "Files"
-
-  """
+  # Extracts the group name from a given URL.
+  # Examples:
+  #   "/fine-tunes/{fine_tune_id}" -> "FineTunes"
+  #   "/files/{file_id}/content" -> "Files"
   defp extract_group_from_url(url) do
     String.split(url, "/")
     |> Enum.at(1)


### PR DESCRIPTION
`defp` having `@doc` gives compiler warning under Elixir v1.18.

Thank you for reviewing.