### PR TITLE
Support for OpenRouter and partial streams

### DIFF
--- a/lib/ex_openai/client.ex
+++ b/lib/ex_openai/client.ex
@@ -110,7 +110,7 @@ defmodule ExOpenAI.Client do
   defp strip_params(params) do
     params
     # remove stream_to from params as PID messes with Jason
-    |> Map.drop([:stream_to, :openai_organization_key, :openai_api_key])
+    |> Map.drop([:stream_to, :openai_organization_key, :openai_api_key, :base_url])
   end
 
   def api_post(url, params \\ [], request_options \\ [], convert_response) do

--- a/lib/ex_openai/streaming_client.ex
+++ b/lib/ex_openai/streaming_client.ex
@@ -148,6 +148,14 @@ defmodule ExOpenAI.StreamingClient do
     {:noreply, state}
   end
 
+  def handle_info(
+        %HTTPoison.AsyncChunk{chunk: ": OPENROUTER PROCESSING\n\n"},
+        state
+      ) do
+    Logger.debug("received : OPENROUTER PROCESSING stamp")
+    {:noreply, state}
+  end
+
   # def handle_info(%HTTPoison.AsyncChunk{chunk: "data: " <> chunk_data}, state) do
   #   Logger.debug("Received AsyncChunk DATA: #{inspect(chunk_data)}")
   # end

--- a/lib/ex_openai/streaming_client.ex
+++ b/lib/ex_openai/streaming_client.ex
@@ -169,6 +169,7 @@ defmodule ExOpenAI.StreamingClient do
     # Split by "data:" lines, but be mindful of partial JSON
     lines =
       new_buffer
+      |> String.replace(": OPENROUTER PROCESSING\n\n", "")
       |> String.split(~r/data: /)
 
     # The first chunk might still hold partial data from the end

--- a/lib/ex_openai/streaming_client.ex
+++ b/lib/ex_openai/streaming_client.ex
@@ -86,7 +86,7 @@ defmodule ExOpenAI.StreamingClient do
             forward_response(pid_or_fx, {:data, res})
 
           {:error, err} ->
-            Logger.warn("Received something that isn't JSON in stream: #{inspect(etc)}")
+            Logger.warning("Received something that isn't JSON in stream: #{inspect(etc)}")
             forward_response(pid_or_fx, {:error, err})
         end
     end

--- a/lib/ex_openai/streaming_client.ex
+++ b/lib/ex_openai/streaming_client.ex
@@ -80,8 +80,16 @@ defmodule ExOpenAI.StreamingClient do
             case Jason.decode(attempt) do
               {:ok, decoded} ->
                 # Once successfully decoded, forward, and reset partial buffer
-                message = st.convert_response_fx.({:ok, decoded})
-                forward_response(st.stream_to, {:data, message})
+                case st.convert_response_fx.({:ok, decoded}) do
+                  {:ok, message} ->
+                    forward_response(st.stream_to, {:data, message})
+
+                  e ->
+                    Logger.warning(
+                      "Something went wrong trying to decode the response: #{inspect(e)}"
+                    )
+                end
+
                 {"", st}
 
               {:error, _} ->

--- a/lib/ex_openai/streaming_client.ex
+++ b/lib/ex_openai/streaming_client.ex
@@ -71,6 +71,9 @@ defmodule ExOpenAI.StreamingClient do
       "event: " <> event_type ->
         Logger.debug("Received event: #{inspect(event_type)}")
 
+      ": OPENROUTER PROCESSING" <> event_type ->
+        Logger.debug("Received event: #{inspect(event_type)}")
+
       etc ->
         Logger.debug("Received event payload: #{inspect(etc)}")
 
@@ -84,7 +87,7 @@ defmodule ExOpenAI.StreamingClient do
 
           {:error, err} ->
             Logger.warn("Received something that isn't JSON in stream: #{inspect(etc)}")
-            # forward_response(pid_or_fx, {:error, err})
+            forward_response(pid_or_fx, {:error, err})
         end
     end
   end

--- a/lib/ex_openai/streaming_client.ex
+++ b/lib/ex_openai/streaming_client.ex
@@ -83,7 +83,8 @@ defmodule ExOpenAI.StreamingClient do
             forward_response(pid_or_fx, {:data, res})
 
           {:error, err} ->
-            forward_response(pid_or_fx, {:error, err})
+            Logger.warn("Received something that isn't JSON in stream: #{inspect(etc)}")
+            # forward_response(pid_or_fx, {:error, err})
         end
     end
   end


### PR DESCRIPTION
Openrouter sends an additional stamp (": OPENROUTER PROCESSING") in the streaming response. To add compatibility, we need to handle that 

Also some openai compatible APIs (for example cloudflare AI gateway) stream partial json. OpenAI has been nice and only send chunks that are proper valid json, but when using other APIs that don't do that, the current implementation breaks.